### PR TITLE
Cancel subscription

### DIFF
--- a/lib/bluebottle/models/subscription.rb
+++ b/lib/bluebottle/models/subscription.rb
@@ -6,13 +6,13 @@ module BlueBottle
       attr_accessor :id,
                     :customer,
                     :coffee,
-                    :active
+                    :status
 
       def initialize(id, customer, coffee)
         @id = id
         @customer = customer
         @coffee = coffee
-        @active = true
+        @status = 'active'
       end
 
       def customer_name

--- a/lib/bluebottle/services/subscription_service.rb
+++ b/lib/bluebottle/services/subscription_service.rb
@@ -11,29 +11,50 @@ module BlueBottle
         @data_store.add_subscription(subscription)
       end
 
+      def pause_subscription(customer, coffee)
+        subscription = find_active_subscriptions_by_customer(customer).find do |subscription|
+          subscription.coffee_name == coffee.name
+        end
+        subscription.status = 'paused'
+      end
+
+      def cancel_subscription(customer, coffee)
+        subscription = find_active_subscriptions_by_customer(customer).find do |subscription|
+          subscription.coffee_name == coffee.name
+        end
+        subscription.status = 'cancelled'
+      end
+
       def find_active_subscriptions_by_customer(customer)
         @data_store.subscriptions.select do |subscription|
-          subscription.customer_name == customer.full_name && subscription.active
+          (subscription.customer_name == customer.full_name) && (subscription.status == 'active')
         end
       end
 
       def find_paused_subscriptions_by_customer(customer)
         @data_store.subscriptions.select do |subscription|
-          subscription.customer_name == customer.full_name && !subscription.active
+          (subscription.customer_name == customer.full_name) && (subscription.status == 'paused')
         end
       end
 
-      def find_subscriptions_by_coffee(coffee)
+      def find_subscriptions_by_coffee(coffee, status = 'any')
+        if status == 'active'
+          find_active_subscriptions_by_coffee(coffee)
+        else
+          find_all_subscriptions_by_coffee(coffee)
+        end
+      end
+
+      def find_all_subscriptions_by_coffee(coffee)
         @data_store.subscriptions.select do |subscription|
           subscription.coffee_name == coffee.name
         end
       end
 
-      def pause_subscription(customer, coffee)
-        subscription = find_active_subscriptions_by_customer(customer).find do |subscription|
-          subscription.coffee_name == coffee.name
+      def find_active_subscriptions_by_coffee(coffee)
+        @data_store.subscriptions.select do |subscription|
+          subscription.coffee_name == coffee.name && subscription.status == 'active'
         end
-        subscription.active = false
       end
     end
   end

--- a/lib/bluebottle/services/subscription_service.rb
+++ b/lib/bluebottle/services/subscription_service.rb
@@ -19,10 +19,28 @@ module BlueBottle
       end
 
       def cancel_subscription(customer, coffee)
-        subscription = find_active_subscriptions_by_customer(customer).find do |subscription|
+        subscription = find_any_subscriptions_by_customer(customer).find do |subscription|
           subscription.coffee_name == coffee.name
         end
+        begin
+          subscription.status == 'active' ? set_subscription_to_canceled(subscription) : refuse_cancelation
+        rescue Exception
+          'Sorry, you cannot cancel a paused subscription.'
+        end
+      end
+
+      def set_subscription_to_canceled(subscription)
         subscription.status = 'cancelled'
+      end
+
+      def refuse_cancelation
+        raise Exception.new('subscription paused')
+      end
+
+      def find_any_subscriptions_by_customer(customer)
+        @data_store.subscriptions.select do |subscription|
+          (subscription.customer_name == customer.full_name)
+        end
       end
 
       def find_active_subscriptions_by_customer(customer)
@@ -30,6 +48,7 @@ module BlueBottle
           (subscription.customer_name == customer.full_name) && (subscription.status == 'active')
         end
       end
+
 
       def find_paused_subscriptions_by_customer(customer)
         @data_store.subscriptions.select do |subscription|

--- a/spec/bluebottle/coding_question_spec.rb
+++ b/spec/bluebottle/coding_question_spec.rb
@@ -70,8 +70,8 @@ describe BlueBottle::CodingQuestion do
   context 'Pausing:' do
     context 'when Liv pauses her subscription to Bella Donovan,' do
       before do
-        subscription_service.new_subscription(2, liv, hayes_valley_espresso)
-        subscription_service.pause_subscription(liv, hayes_valley_espresso)
+        subscription_service.new_subscription(2, liv, bella_donovan)
+        subscription_service.pause_subscription(liv, bella_donovan)
       end
 
       it 'Liv should have zero active subscriptions' do
@@ -82,7 +82,7 @@ describe BlueBottle::CodingQuestion do
         expect(subscription_service.find_paused_subscriptions_by_customer(liv).count).to eql(1)
       end
 
-      xit 'Bella Donovan should have one customers subscribed to it' do
+      it 'Bella Donovan should have one customers subscribed to it' do
         expect(subscription_service.find_subscriptions_by_coffee(bella_donovan).count).to eql(1)
       end
     end
@@ -91,13 +91,16 @@ describe BlueBottle::CodingQuestion do
   context 'Cancelling:' do
     context 'when Jack cancels his subscription to Bella Donovan,' do
       before do
-        # Establish subscription here
+        subscription_service.new_subscription(1, jack, bella_donovan)
+        subscription_service.cancel_subscription(jack, bella_donovan)
       end
 
-      xit 'Jack should have zero active subscriptions' do
+      it 'Jack should have zero active subscriptions' do
+        expect(subscription_service.find_active_subscriptions_by_customer(jack).count).to eql(0)
       end
 
-      xit 'Bella Donovan should have zero active customers subscribed to it' do
+      it 'Bella Donovan should have zero active customers subscribed to it' do
+        expect(subscription_service.find_subscriptions_by_coffee(bella_donovan, 'active').count).to eql(0)
       end
 
       context 'when Jack resubscribes to Bella Donovan' do

--- a/spec/bluebottle/coding_question_spec.rb
+++ b/spec/bluebottle/coding_question_spec.rb
@@ -105,10 +105,13 @@ describe BlueBottle::CodingQuestion do
 
       context 'when Jack resubscribes to Bella Donovan' do
         before do
-          # Establish subscription here
+          subscription_service.new_subscription(2, jack, bella_donovan)
         end
 
-        xit 'Bella Donovan has two subscriptions, one active, one cancelled' do
+        it 'Bella Donovan has two subscriptions, one active, one cancelled' do
+          expect(subscription_service.find_subscriptions_by_coffee(bella_donovan).count).to eql(2)
+          expect(subscription_service.find_subscriptions_by_coffee(bella_donovan)[0].status).to eql('cancelled')
+          expect(subscription_service.find_subscriptions_by_coffee(bella_donovan)[1].status).to eql('active')
         end
 
       end
@@ -118,10 +121,12 @@ describe BlueBottle::CodingQuestion do
   context 'Cancelling while Paused:' do
     context 'when Jack tries to cancel his paused subscription to Bella Donovan,' do
       before do
-        # Establish paused subscription here
+        subscription_service.new_subscription(1, jack, bella_donovan)
+        subscription_service.pause_subscription(jack, bella_donovan)
       end
 
-      xit 'Jack raises an exception preventing him from cancelling a paused subscription' do
+      it 'Jack raises an exception preventing him from cancelling a paused subscription' do
+        expect(subscription_service.cancel_subscription(jack, bella_donovan)).to eql('Sorry, you cannot cancel a paused subscription.')
       end
     end
   end


### PR DESCRIPTION
- User can now cancel subscription for customer:
  - If customer's subscription is active subscription cancels
  - If customer's subscription is paused an exception is raised

This commit completes base functionality
